### PR TITLE
Add Valuation module, removed PromotionController and Property seeder

### DIFF
--- a/backend/zillow-backend/app/Http/Controllers/ValuationController.php
+++ b/backend/zillow-backend/app/Http/Controllers/ValuationController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Property;
+use App\Models\Valuation;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class ValuationController extends Controller
+{
+    public function index()
+    {
+        $valuations = Valuation::whereHas('property', function ($query) {
+            $query->where('user_id', Auth::id());
+        })->with('property')->paginate(10);
+        return response()->json($valuations);
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate(['property_id' => 'required|exists:properties,id']);
+        $property = Property::findOrFail($request->property_id);
+
+        if ($property->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+
+        $estimatedValue = $this->calculateValuation($property);
+        $valuation = Valuation::create([
+            'property_id' => $property->id,
+            'estimated_value' => $estimatedValue,
+            'trend_data' => json_encode(['last_year' => $estimatedValue * 0.95, 'trend' => 'up']),
+            'calculated_at' => now(),
+        ]);
+
+        return response()->json($valuation, 201);
+    }
+
+    public function show(Valuation $valuation)
+    {
+        if ($valuation->property->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $valuation->load('property');
+        return response()->json($valuation);
+    }
+
+    public function update(Request $request, Valuation $valuation)
+    {
+        if ($valuation->property->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $validated = $request->validate([
+            'estimated_value' => 'sometimes|numeric|min:0',
+            'trend_data' => 'sometimes|json',
+        ]);
+        $valuation->update($validated);
+        return response()->json($valuation);
+    }
+
+    public function destroy(Valuation $valuation)
+    {
+        if ($valuation->property->user_id !== Auth::id()) {
+            return response()->json(['message' => 'Unauthorized'], 403);
+        }
+        $valuation->delete();
+        return response()->json(['message' => 'Valuation deleted successfully']);
+    }
+
+    private function calculateValuation(Property $property)
+    {
+        $baseValue = $property->price ?? 100000;
+        $sizeFactor = $property->square_feet ? $property->square_feet * 100 : 0;
+        $bedroomFactor = $property->bedrooms ? $property->bedrooms * 10000 : 0;
+        return $baseValue + $sizeFactor + $bedroomFactor;
+    }
+}

--- a/backend/zillow-backend/app/Models/Property.php
+++ b/backend/zillow-backend/app/Models/Property.php
@@ -36,10 +36,10 @@ class Property extends Model
         return $this->belongsToMany(User::class, 'favorites')->withTimestamps();
     }
 
-
     public function valuation()
     {
         return $this->hasOne(Valuation::class);
     }
+  
 
 }

--- a/backend/zillow-backend/app/Models/Valuation.php
+++ b/backend/zillow-backend/app/Models/Valuation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Valuation extends Model
+{
+    protected $fillable = [
+        'property_id', 'estimated_value', 'trend_data', 'calculated_at'
+    ];
+
+    protected $casts = [
+        'trend_data' => 'array',
+        'calculated_at' => 'datetime',
+    ];
+
+    public function property()
+    {
+        return $this->belongsTo(Property::class);
+    }
+}

--- a/backend/zillow-backend/database/migrations/2025_03_21_142510_create_valuations_table.php
+++ b/backend/zillow-backend/database/migrations/2025_03_21_142510_create_valuations_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('valuations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('property_id')->constrained()->onDelete('cascade');
+            $table->decimal('estimated_value', 15, 2);
+            $table->json('trend_data')->nullable();
+            $table->timestamp('calculated_at');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('valuations');
+    }
+};

--- a/backend/zillow-backend/database/seeders/DatabaseSeeder.php
+++ b/backend/zillow-backend/database/seeders/DatabaseSeeder.php
@@ -15,7 +15,7 @@ class DatabaseSeeder extends Seeder
    
     {
         $this->call([
-            PropertySeeder::class,
+           
             RoleSeeder::class,
             PermissionSeeder::class,
             RolePermissionSeeder::class,

--- a/backend/zillow-backend/routes/api.php
+++ b/backend/zillow-backend/routes/api.php
@@ -2,8 +2,9 @@
 
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\PropertyController;
-use App\Http\Controllers\PromotionController;
+
 use App\Http\Controllers\SearchController;
+use App\Http\Controllers\ValuationController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('register', [AuthController::class, 'register']);
@@ -12,9 +13,9 @@ Route::post('logout', [AuthController::class, 'logout'])->middleware('auth:sanct
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::apiResource('properties', PropertyController::class);
-    Route::post('properties/{property}/promote', [PromotionController::class, 'store']);
-    Route::delete('properties/{property}/promote', [PromotionController::class, 'destroy']);
+ 
     Route::get('search', [SearchController::class, 'search']);
     Route::get('neighborhood-insights', [SearchController::class, 'neighborhoodInsights']);
+    Route::apiResource('valuations', ValuationController::class);
    
 });

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   frontend:
     build:
-      context: ../frontend/zillow-frontend
+      context: ../frontend/keja-frontend
       dockerfile: ../../docker/Dockerfile.frontend
     container_name: angular-frontend
     


### PR DESCRIPTION
- Implemented ValuationController with CRUD operations for property valuations
- Added valuation calculation logic based on price, square footage, and bedrooms
- Created Valuation model, migration, and API routes for /api/valuations
- Deleted PromotionController and its associated route for sponsorships
- Removed PropertySeeder to stop seeding test data in properties table
- Updated API to support manual property creation for testing valuations